### PR TITLE
Fix UserModel typo

### DIFF
--- a/backbone.js/what-is-a-model/index.md
+++ b/backbone.js/what-is-a-model/index.md
@@ -200,7 +200,7 @@ If we instantiate a model with an `id`, Backbone.js will automatically perform a
 ```js
 
 // Here we have set the `id` of the model
-var user = new Usermodel({id: 1});
+var user = new UserModel({id: 1});
 
 // The fetch below will perform GET /user/1
 // The server should return the id, name and email from the database
@@ -220,7 +220,7 @@ We will use the `save` api call which is intelligent and will send a PUT request
 ```js
 
 // Here we have set the id of the model
-var user = new Usermodel({
+var user = new UserModel({
   id: 1,
   name: 'Thomas',
   email: 'thomasalwyndavis@gmail.com'
@@ -244,7 +244,7 @@ When a model has an `id` we know that it exists on the server, so if we wish to 
 
 ```js
 // Here we have set the id of the model
-var user = new Usermodel({
+var user = new UserModel({
   id: 1,
   name: 'Thomas',
   email: 'thomasalwyndavis@gmail.com'


### PR DESCRIPTION
Fixing more instances of the same typo, "Usermodel" instead of "UserModel".