### PR TITLE
Updates Model tutorial so that validation works

### DIFF
--- a/backbone.js/what-is-a-model/index.md
+++ b/backbone.js/what-is-a-model/index.md
@@ -5,7 +5,7 @@ Across the internet the definition of [MVC](http://en.wikipedia.org/wiki/Model%E
 > Models are the heart of any JavaScript application, containing the interactive data as well as a large part of the logic surrounding it: conversions, validations, computed properties, and access control.
 
 So for the purpose of the tutorial let's create a `model`.
-    
+
 
 ```js
 var Human = Backbone.Model.extend({
@@ -40,7 +40,7 @@ human.set({ name: "Thomas", age: 67});
 
 ```
 
-So passing a JavaScript object to our constructor is the same as calling _model.set()_.   Now that these models have attributes set we need to be able to retrieve them.  
+So passing a JavaScript object to our constructor is the same as calling _model.set()_.   Now that these models have attributes set we need to be able to retrieve them.
 
 ## Getting attributes
 
@@ -108,7 +108,7 @@ human.adopt('John Resig');
 var child = human.get("child"); // 'John Resig'
 ```
 
-So we can implement methods to get/set and perform other calculations using attributes from our model at any time.   
+So we can implement methods to get/set and perform other calculations using attributes from our model at any time.
 
 ## Listening for changes to the model
 
@@ -160,7 +160,7 @@ var UserModel = Backbone.Model.extend({
 
 ### Creating a new model
 
-If we wish to create a new user on the server then we will instantiate a new UserModel and call `save`.  If the `id` attribute of the model is `null`, Backbone.js will send a POST request to the urlRoot of the server. 
+If we wish to create a new user on the server then we will instantiate a new UserModel and call `save`.  If the `id` attribute of the model is `null`, Backbone.js will send a POST request to the urlRoot of the server.
 
 ```js
 var UserModel = Backbone.Model.extend({
@@ -251,7 +251,7 @@ var user = new UserModel({
 });
 
 // Because there is id present, Backbone.js will fire
-// DELETE /user/1 
+// DELETE /user/1
 user.destroy({
   success: function () {
     alert('Destroyed');
@@ -300,7 +300,7 @@ human.set({ name: "Mary Poppins", age: -1 });
 var human = new Human;
 human.set({ name: "Dr Manhatten", age: -1 });
 // God have mercy on our souls
-    
+
 ```
 
 ### Contributors

--- a/backbone.js/what-is-a-model/index.md
+++ b/backbone.js/what-is-a-model/index.md
@@ -286,7 +286,7 @@ var Human = Backbone.Model.extend({
   },
   initialize: function(){
     alert("Welcome to this world");
-    this.bind("error", function(model, error){
+    this.bind("invalid", function(model, error){
       // We have received an error, log it, alert it or forget it :)
       alert( error );
     });
@@ -294,11 +294,11 @@ var Human = Backbone.Model.extend({
 });
 
 var human = new Human;
-human.set({ name: "Mary Poppins", age: -1 }); 
+human.set({ name: "Mary Poppins", age: -1 }, {validate: true});
 // Will trigger an alert outputting the error
 
 var human = new Human;
-human.set({ name: "Dr Manhatten", age: -1 });
+human.set({ name: "Dr Manhatten", age: -1 }, {validate: true});
 // God have mercy on our souls
 
 ```

--- a/backbone.js/what-is-a-view/index.md
+++ b/backbone.js/what-is-a-view/index.md
@@ -33,7 +33,7 @@ Let us set our view's "el" property to div#search_container, effectively making 
       alert("Alerts suck.");
     }
   });
-  
+
   var search_view = new SearchView({ el: $("#search_container") });
 </script>
 ```
@@ -68,7 +68,7 @@ Let us implement a "render()" function and call it when the view is initialized.
       this.$el.html( template );
     }
   });
-  
+
   var search_view = new SearchView({ el: $("#search_container") });
 </script>
 
@@ -145,14 +145,14 @@ _Using template variables_
       this.$el.html( interpolatedTemplate );
     },
     events: {
-      "click input[type=button]": "doSearch"  
+      "click input[type=button]": "doSearch"
     },
     doSearch: function( event ){
       // Button clicked, you can access the element that was clicked with event.currentTarget
       alert( "Search for " + $("#search_input").val() );
     }
   });
-    
+
   var search_view = new SearchView({ el: $("#search_container") });
 </script>
 

--- a/backbone.js/what-is-a-view/index.md
+++ b/backbone.js/what-is-a-view/index.md
@@ -135,11 +135,14 @@ _Using template variables_
     },
     render: function(){
       //Pass variables in using Underscore.js Template
-      var variables = { search_label: "My Search" };
-      // Compile the template using underscore
-      var template = _.template( $("#search_template").html(), variables );
+      var tplVariables = { search_label: "My Search" };
+      //Compile the template into a function using Underscore
+      var template = _.template( $("#search_template").html());
+      // Fill in the template variables with your data by calling the
+      //compiled template as a function
+      var interpolatedTemplate = template(tplVariables);
       // Load the compiled HTML into the Backbone "el"
-      this.$el.html( template );
+      this.$el.html( interpolatedTemplate );
     },
     events: {
       "click input[type=button]": "doSearch"  


### PR DESCRIPTION
Why:
- The `What is a Model?` tutorial did not work as expected when going through the validation example because validation errors no longer raise _**error**_, they raise _**invalid**_. Additionally, _**invalid**_ is only triggered by default during a call to `Model.save`, while `Model.set` requires setting the `validate` option to true.

This change addresses the need by:
- Changing the event trigger from _**error**_ to _**invalid**_.
- Adding the `{validate: true}` option to the `Model.set` calls in the validation example.
- Also cleaning up some trailing white space.

Side effects of this change:
- n/a

Issue link:
- n/a
